### PR TITLE
Remove intro summary section and update profile copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,51 +155,6 @@
     box-shadow: 0 12px 35px -16px rgba(15, 23, 42, 0.8);
   }
 
-  .intro-card {
-    margin-top: 24px;
-    margin-bottom: 28px;
-    padding: 28px;
-    background: var(--card);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow);
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    display: grid;
-    gap: 18px;
-  }
-
-  .intro-card p {
-    margin: 0;
-    font-size: 1rem;
-    color: var(--muted);
-  }
-
-  .highlight-metrics {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 18px;
-  }
-
-  .metric {
-    background: var(--bg-alt);
-    border-radius: calc(var(--radius) - 6px);
-    padding: 18px;
-    border: 1px solid rgba(148, 163, 184, 0.18);
-  }
-
-  .metric strong {
-    display: block;
-    font-size: 1.6rem;
-    color: var(--brand);
-    line-height: 1.2;
-  }
-
-  .metric span {
-    display: block;
-    font-size: 0.9rem;
-    color: var(--muted);
-    margin-top: 6px;
-  }
-
   details.block {
     border: 1px solid rgba(148, 163, 184, 0.2);
     border-radius: var(--radius);
@@ -393,30 +348,10 @@
     <img src="https://rbecker1014.github.io/resume/thumb.jpg" alt="Rick Becker" class="thumb" />
   </header>
 
-  <section class="intro-card">
-    <p>
-      Technology-driven insurance executive with 30+ years of experience modernizing underwriting, claims, and operations to deliver scalable platforms for MGAs and carriers. Proven leader in orchestrating digital transformation, optimizing cross-functional teams, and turning complex strategy into measurable growth.
-    </p>
-    <div class="highlight-metrics">
-      <div class="metric">
-        <strong>$288M+</strong>
-        <span>Gross written premium enabled through digital platform launches.</span>
-      </div>
-      <div class="metric">
-        <strong>218%</strong>
-        <span>Productivity lift delivered by reorganizing IT support operations.</span>
-      </div>
-      <div class="metric">
-        <strong>60%</strong>
-        <span>Configuration efficiency gained via modernized implementation playbooks.</span>
-      </div>
-    </div>
-  </section>
-
   <details class="block" open>
     <summary class="block"><strong>Profile</strong></summary>
     <div class="content">
-       <p>Entrepreneurial insurance executive known for aligning digital products, policy administration, and claims technologies to growth strategies. Skilled at building high-performing cultures that blend underwriting rigor with data-driven technology delivery, resulting in material revenue gains, expense savings, and operational resilience.</p>
+       <p>Technology-driven insurance executive with 30+ years of experience modernizing underwriting, claims, and operations, delivering scalable platforms for MGAs and carriers, and leading high-performing teams across technology, product, and underwriting to drive innovation and growth.</p>
     </div>
   </details>
 


### PR DESCRIPTION
## Summary
- remove the introductory highlight card and its associated styling from the resume layout
- refresh the Profile section copy with the provided leadership-focused summary

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68e40e5aa6288329bed63d1c914fe399